### PR TITLE
Add integration.yml for ci steps

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,34 @@
+name: Integration
+
+on:
+  workflow_dispatch: {}
+  push:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Run Tests
+        run: poetry run pytest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for integration testing. The workflow is triggered by various events and runs on the latest Ubuntu environment. It sets up Python, installs dependencies using Poetry, and runs tests using pytest.

Key changes:

* Added a new workflow named `Integration` in `.github/workflows/integration.yml` that triggers on `workflow_dispatch`, `push`, and `pull_request` events.
* Configured the workflow to run on `ubuntu-latest` and included steps to checkout the code, set up Python 3.12, install dependencies with Poetry, and run tests using pytest.