### PR TITLE
fix: random search policy expansion bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.1.0"
+version = "0.1.1"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/internal/models/search/random_policy.py
+++ b/smolmodels/internal/models/search/random_policy.py
@@ -67,11 +67,16 @@ class RandomSearchPolicy(SearchPolicy):
         :return: A list containing one randomly selected node.
         :raises NotImplementedError: If n is not 1.
         """
-        # n must be a positive integer less than the number of good nodes
-        if not 0 < n <= len(self.graph.good_nodes):
-            raise ValueError(f"Cannot select {n} nodes for expansion from {len(self.graph.good_nodes)} available.")
-        # if there are no good nodes, return the first node
-        if not self.graph.good_nodes:
-            return [self.graph.nodes[0]] if self.graph.nodes else []
-        # else return a random sample of good nodes
-        return random.sample(self.graph.good_nodes, min(n, len(self.graph.good_nodes)))
+        # n must be a positive integer less than the number of available nodes
+        if not 0 < n <= len(self.graph.nodes):
+            raise ValueError(f"Cannot select {n} nodes for expansion from {len(self.graph.nodes)} available.")
+        # Prefer to expand visited good nodes, then visited buggy nodes
+        nodes = []
+        if self.graph.good_nodes:
+            nodes.extend(random.sample(self.graph.good_nodes, min(n, len(self.graph.good_nodes))))
+        if len(nodes) < n and self.graph.buggy_nodes:
+            nodes.extend(random.sample(self.graph.buggy_nodes, min(n - len(nodes), len(self.graph.buggy_nodes))))
+        # If no nodes have been visited, return the first node
+        if len(nodes) == 0:
+            nodes.append(self.graph.nodes[0])
+        return nodes


### PR DESCRIPTION
This pull request fixes a bug whereby the node expansion selection logic fails if no "good" nodes exist yet in the graph. Now the function prefers good nodes, but can also return buggy nodes if not enough good nodes are available.

### Improvements to node selection logic:

* [`smolmodels/internal/models/search/random_policy.py`](diffhunk://#diff-d66f8349c632f192a8a3f3074f24061efedccab1b49493aa9ae0a26eb31086feL70-R82): The method now prefers to expand visited good nodes first, and if necessary, expands visited buggy nodes. It also ensures that if no nodes have been visited, the first node is returned. This change enhances the robustness and accuracy of node selection.