### PR TITLE
fix: semantic release GA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:  # Allow manual triggering
-    inputs:
-      dry_run:
-        description: 'Test build without publishing'
-        type: boolean
-        default: true
-        required: true
 
 jobs:
   publish:
@@ -35,17 +29,12 @@ jobs:
           pip install poetry
 
       - name: Configure Poetry with PyPI token
-        if: github.event_name == 'release' || inputs.dry_run == false
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
 
       - name: Build Package
         run: poetry build
 
-      - name: List Build Output
-        run: ls -l dist/
-
       - name: Publish to PyPI
-        if: github.event_name == 'release' || inputs.dry_run == false
         run: poetry publish
 
       - name: Upload Release Assets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:  # Allow manual triggering
+    inputs:
+      dry_run:
+        description: 'Test build without publishing'
+        type: boolean
+        default: true
+        required: true
 
 jobs:
   publish:
@@ -29,12 +35,17 @@ jobs:
           pip install poetry
 
       - name: Configure Poetry with PyPI token
+        if: github.event_name == 'release' || inputs.dry_run == false
         run: poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
 
       - name: Build Package
         run: poetry build
 
+      - name: List Build Output
+        run: ls -l dist/
+
       - name: Publish to PyPI
+        if: github.event_name == 'release' || inputs.dry_run == false
         run: poetry publish
 
       - name: Upload Release Assets

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,9 +1,18 @@
 name: Semantic Release
 
 on:
+  # Production release trigger
   push:
     branches:
       - main
+  # Manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no actual release)'
+        type: boolean
+        default: true
+        required: true
 
 jobs:
   release:
@@ -17,17 +26,32 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
 
-      - name: Install Poetry
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install poetry
+          pip install python-semantic-release
 
+      # Run semantic release
       - name: Python Semantic Release
-        uses: python-semantic-release/python-semantic-release@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.dry_run }}" == "true" ]]; then
+            semantic-release version --dry-run
+          else
+            semantic-release version
+          fi
+
+      # Only build and publish if this is a real release
+      - name: Build and publish
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
+        run: |
+          poetry build
+          # Add publish step here when ready


### PR DESCRIPTION
Fix `semantic-release` workflow by:
- Installing poetry directly rather than using container
- Using pip to install semantic-release instead of the action
- Running semantic-release in dry-run mode when testing

