### PR TITLE
feature: support common datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ plain English. Instead of wrestling with model architectures and hyperparameters
 define your inputs and outputs, and let `smolmodels` handle the rest.
 
 ```python
+import pandas as pd
 import smolmodels as sm
 
 # Define a house price predictor in terms of inputs, outputs, and expected behaviour
@@ -31,7 +32,11 @@ model = sm.Model(
 )
 
 # Build the model, using the backend of your choice; optionally generate synthetic training data
-model.build("house-prices.csv", generate_samples=1000, provider="openai:gpt-4o-mini")
+model.build(
+   dataset=pd.read_csv("house-prices.csv"),
+   generate_samples=1000,
+   provider="openai:gpt-4o-mini"
+)
 
 # Make predictions
 price = model.predict({
@@ -114,7 +119,7 @@ You can use multiple LLM providers as a backend for model generation. You can sp
 format `provider:[model]` when calling `build()`:
 
 ```python
-model.build("house-prices.csv", provider="openai:gpt-4o-mini")
+model.build(pd.read_csv("house-prices.csv"), provider="openai:gpt-4o-mini")
 ```
 
 Currently supported providers are `openai`, `anthropic`, `google` and `deepseek`. You need to configure the
@@ -155,7 +160,7 @@ model = sm.Model(
 
 ```python
 # Build with existing data
-model.build(dataset="feedback.csv", provider="openai:gpt-4o-mini")
+model.build(dataset=pd.read_csv("feedback.csv"), provider="openai:gpt-4o-mini")
 
 # Or generate synthetic data
 model.build(generate_samples=1000)

--- a/poetry.lock
+++ b/poetry.lock
@@ -3147,6 +3147,60 @@ files = [
 tests = ["pytest"]
 
 [[package]]
+name = "pyarrow"
+version = "19.0.0"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pyarrow-19.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c318eda14f6627966997a7d8c374a87d084a94e4e38e9abbe97395c215830e0c"},
+    {file = "pyarrow-19.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:62ef8360ff256e960f57ce0299090fb86423afed5e46f18f1225f960e05aae3d"},
+    {file = "pyarrow-19.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2795064647add0f16563e57e3d294dbfc067b723f0fd82ecd80af56dad15f503"},
+    {file = "pyarrow-19.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a218670b26fb1bc74796458d97bcab072765f9b524f95b2fccad70158feb8b17"},
+    {file = "pyarrow-19.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:66732e39eaa2247996a6b04c8aa33e3503d351831424cdf8d2e9a0582ac54b34"},
+    {file = "pyarrow-19.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e675a3ad4732b92d72e4d24009707e923cab76b0d088e5054914f11a797ebe44"},
+    {file = "pyarrow-19.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:f094742275586cdd6b1a03655ccff3b24b2610c3af76f810356c4c71d24a2a6c"},
+    {file = "pyarrow-19.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:8e3a839bf36ec03b4315dc924d36dcde5444a50066f1c10f8290293c0427b46a"},
+    {file = "pyarrow-19.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:ce42275097512d9e4e4a39aade58ef2b3798a93aa3026566b7892177c266f735"},
+    {file = "pyarrow-19.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9348a0137568c45601b031a8d118275069435f151cbb77e6a08a27e8125f59d4"},
+    {file = "pyarrow-19.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a0144a712d990d60f7f42b7a31f0acaccf4c1e43e957f7b1ad58150d6f639c1"},
+    {file = "pyarrow-19.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2a1a109dfda558eb011e5f6385837daffd920d54ca00669f7a11132d0b1e6042"},
+    {file = "pyarrow-19.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:be686bf625aa7b9bada18defb3a3ea3981c1099697239788ff111d87f04cd263"},
+    {file = "pyarrow-19.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:239ca66d9a05844bdf5af128861af525e14df3c9591bcc05bac25918e650d3a2"},
+    {file = "pyarrow-19.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:a7bbe7109ab6198688b7079cbad5a8c22de4d47c4880d8e4847520a83b0d1b68"},
+    {file = "pyarrow-19.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:4624c89d6f777c580e8732c27bb8e77fd1433b89707f17c04af7635dd9638351"},
+    {file = "pyarrow-19.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b6d3ce4288793350dc2d08d1e184fd70631ea22a4ff9ea5c4ff182130249d9b"},
+    {file = "pyarrow-19.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:450a7d27e840e4d9a384b5c77199d489b401529e75a3b7a3799d4cd7957f2f9c"},
+    {file = "pyarrow-19.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:a08e2a8a039a3f72afb67a6668180f09fddaa38fe0d21f13212b4aba4b5d2451"},
+    {file = "pyarrow-19.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f43f5aef2a13d4d56adadae5720d1fed4c1356c993eda8b59dace4b5983843c1"},
+    {file = "pyarrow-19.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:2f672f5364b2d7829ef7c94be199bb88bf5661dd485e21d2d37de12ccb78a136"},
+    {file = "pyarrow-19.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:cf3bf0ce511b833f7bc5f5bb3127ba731e97222023a444b7359f3a22e2a3b463"},
+    {file = "pyarrow-19.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:4d8b0c0de0a73df1f1bf439af1b60f273d719d70648e898bc077547649bb8352"},
+    {file = "pyarrow-19.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92aff08e23d281c69835e4a47b80569242a504095ef6a6223c1f6bb8883431d"},
+    {file = "pyarrow-19.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3b78eff5968a1889a0f3bc81ca57e1e19b75f664d9c61a42a604bf9d8402aae"},
+    {file = "pyarrow-19.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b34d3bde38eba66190b215bae441646330f8e9da05c29e4b5dd3e41bde701098"},
+    {file = "pyarrow-19.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5418d4d0fab3a0ed497bad21d17a7973aad336d66ad4932a3f5f7480d4ca0c04"},
+    {file = "pyarrow-19.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e82c3d5e44e969c217827b780ed8faf7ac4c53f934ae9238872e749fa531f7c9"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:f208c3b58a6df3b239e0bb130e13bc7487ed14f39a9ff357b6415e3f6339b560"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:c751c1c93955b7a84c06794df46f1cec93e18610dcd5ab7d08e89a81df70a849"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b903afaa5df66d50fc38672ad095806443b05f202c792694f3a604ead7c6ea6e"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a22a4bc0937856263df8b94f2f2781b33dd7f876f787ed746608e06902d691a5"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:5e8a28b918e2e878c918f6d89137386c06fe577cd08d73a6be8dafb317dc2d73"},
+    {file = "pyarrow-19.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:29cd86c8001a94f768f79440bf83fee23963af5e7bc68ce3a7e5f120e17edf89"},
+    {file = "pyarrow-19.0.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:c0423393e4a07ff6fea08feb44153302dd261d0551cc3b538ea7a5dc853af43a"},
+    {file = "pyarrow-19.0.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:718947fb6d82409013a74b176bf93e0f49ef952d8a2ecd068fecd192a97885b7"},
+    {file = "pyarrow-19.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c1c162c4660e0978411a4761f91113dde8da3433683efa473501254563dcbe8"},
+    {file = "pyarrow-19.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c73268cf557e688efb60f1ccbc7376f7e18cd8e2acae9e663e98b194c40c1a2d"},
+    {file = "pyarrow-19.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:edfe6d3916e915ada9acc4e48f6dafca7efdbad2e6283db6fd9385a1b23055f1"},
+    {file = "pyarrow-19.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:da410b70a7ab8eb524112f037a7a35da7128b33d484f7671a264a4c224ac131d"},
+    {file = "pyarrow-19.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:597360ffc71fc8cceea1aec1fb60cb510571a744fffc87db33d551d5de919bec"},
+    {file = "pyarrow-19.0.0.tar.gz", hash = "sha256:8d47c691765cf497aaeed4954d226568563f1b3b74ff61139f2d77876717084b"},
+]
+
+[package.extras]
+test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -4540,4 +4594,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "83d31fee5bc358c6a32c4284b2d2763f9d6c60b41c735229ec4c041050c9495d"
+content-hash = "e579ef04f997364b64cb638b12ea34018d237f6765345ab9bf1deffd535ee364"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.1.3"
+version = "0.2.0"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ mlxtend = "^0.23.4"
 xgboost = "^2.1.3"
 instructor = { extras = ["anthropic"], version = "^1.7.2" }
 tenacity = "^9.0.0"
+pyarrow = "^19.0.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.1.2"
+version = "0.1.3"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/config.py
+++ b/smolmodels/config.py
@@ -30,12 +30,12 @@ class _Config:
     class _ExecutionConfig:
         timeout: int = field(default=300)
         runfile_name: str = field(default="execution_script.py")
-        training_data_path: str = field(default="training_data.csv")
+        training_data_path: str = field(default="training_data.parquet")
 
     @dataclass(frozen=True)
     class _CodeGenerationConfig:
         allowed_packages: List[str] = field(
-            default_factory=lambda: ["pandas", "numpy", "scikit-learn", "joblib" "mlxtend" "xgboost"]
+            default_factory=lambda: ["pandas", "numpy", "scikit-learn", "joblib", "mlxtend", "xgboost", "pyarrow"]
         )
         k_fold_validation: int = field(default=5)
         # prompts used in generating plans or making decisions
@@ -88,7 +88,8 @@ class _Config:
                 "# PREVIOUS ATTEMPTS, IF ANY:\n${history}\n\n"
                 "Only return the code to train the model, no explanations outside the code. Any explanation should "
                 "be in the comments in the code itself, but your overall answer must only consist of the code script. "
-                "The script must assume that the dataset is in the current working directory as ${training_data_path}. "
+                "The script must assume that the dataset is in the current working directory as a parquet file "
+                "called ${training_data_path}. "
                 "The script must train the model, compute and print the final evaluation metric to standard output, "
                 "and save the model as 'model.joblib' in the current working directory. Use only ${allowed_packages}. "
                 "Do NOT use any packages that are not part of this list of the Python standard library."
@@ -105,7 +106,7 @@ class _Config:
                 "Correct the code, train the model, compute and print the evaluation metric, and save the model in "
                 "the current working directory as 'model.joblib'. Use only ${allowed_packages}. Do NOT use any "
                 "packages that are not part of this list of the Python standard library. Assume the training "
-                "data is in the current working directory as ${training_data_path}."
+                "data is in the current working directory as a parquet file called ${training_data_path}."
             )
         )
         prompt_training_review: Template = field(

--- a/smolmodels/internal/common/datasets/adapter.py
+++ b/smolmodels/internal/common/datasets/adapter.py
@@ -1,0 +1,49 @@
+# smolmodels/internal/common/datasets/adapter.py
+
+"""
+This module provides the DatasetAdapter class, which converts various dataset formats
+into a standard Pandas DataFrame representation. This enables the library to accept multiple
+dataset types as inputs, while ensuring consistency and interoperability.
+"""
+
+from typing import Any
+import pandas as pd
+import numpy as np
+
+
+class DatasetAdapter:
+    """
+    A utility class for converting different dataset formats into Pandas DataFrames.
+
+    This class provides a standardized method for handling structured datasets,
+    ensuring compatibility with downstream processing steps.
+
+    Currently, the class supports:
+      - Pandas DataFrames (returns a copy).
+      - NumPy arrays (converted to a DataFrame).
+
+    Future extensions will include:
+      - Support for lazy datasets (e.g., Generators, Iterators).
+      - Integration with PyTorch, TensorFlow, and Hugging Face datasets.
+    """
+
+    @staticmethod
+    def convert(dataset: Any) -> pd.DataFrame:
+        """
+        Convert a dataset into a Pandas DataFrame.
+
+        If the dataset is already a Pandas DataFrame, a copy is returned.
+        If the dataset is a NumPy array, it is converted into a DataFrame.
+
+        :param dataset: The dataset to convert. Must be a Pandas DataFrame or NumPy array.
+        :return: A Pandas DataFrame containing the dataset.
+        :raises ValueError: If the dataset type is unsupported.
+        """
+        if isinstance(dataset, pd.DataFrame):
+            return dataset.copy()
+        elif isinstance(dataset, np.ndarray):
+            return pd.DataFrame(dataset)
+        # TODO: Add support for lazy datasets (Generators, Iterators)
+        # TODO: Add support for PyTorch, TensorFlow, and Hugging Face datasets
+        else:
+            raise ValueError(f"Unsupported dataset type: {type(dataset)}")

--- a/smolmodels/internal/models/execution/process_executor.py
+++ b/smolmodels/internal/models/execution/process_executor.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 import time
 import pandas as pd
+import pyarrow.parquet as pq
+import pyarrow as pa
 from pathlib import Path
 
 from smolmodels.internal.common.utils.response import extract_performance
@@ -78,7 +80,7 @@ class ProcessExecutor(Executor):
 
         # Write dataset to file
         dataset_file: Path = self.working_dir / config.execution.training_data_path
-        self.dataset.to_csv(dataset_file, index=False)
+        pq.write_table(pa.Table.from_pandas(df=self.dataset), dataset_file)
 
         try:
             # Execute the code in a subprocess

--- a/smolmodels/models.py
+++ b/smolmodels/models.py
@@ -14,23 +14,23 @@ Key Features:
 - Mutable State: Tracks the model's lifecycle, training metrics, and metadata.
 - Build Process: Integrates solution generation with directives and callbacks.
 
-Example Usage:
-    model = Model(
-        intent="Given a dataset of house features, predict the house price.",
-        output_schema={"price": float},
-        input_schema={
-            "bedrooms": int,
-            "bathrooms": int,
-            "square_footage": float
-        }
-    )
-
-    model.build(dataset="houses.csv", directives=[Directive("Optimize for memory usage")])
-
-    prediction = model.predict({"bedrooms": 3, "bathrooms": 2, "square_footage": 1500.0})
-    print(prediction)
-
+Example:
+>>>    model = Model(
+>>>        intent="Given a dataset of house features, predict the house price.",
+>>>        output_schema={"price": float},
+>>>        input_schema={
+>>>            "bedrooms": int,
+>>>            "bathrooms": int,
+>>>            "square_footage": float
+>>>        }
+>>>    )
+>>>
+>>>    model.build(dataset=pd.read_csv("houses.csv"), provider="openai:gpt-4o-mini")
+>>>
+>>>    prediction = model.predict({"bedrooms": 3, "bathrooms": 2, "square_footage": 1500.0})
+>>>    print(prediction)
 """
+
 import io
 import logging
 import pickle

--- a/smolmodels/models.py
+++ b/smolmodels/models.py
@@ -42,8 +42,9 @@ import uuid
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Optional, Union, List, Literal, Any
+from typing import Dict, Union, List, Literal, Any
 
+import numpy as np
 import pandas as pd
 
 from smolmodels.callbacks import Callback
@@ -51,6 +52,7 @@ from smolmodels.config import config
 from smolmodels.constraints import Constraint
 from smolmodels.directives import Directive
 from smolmodels.internal.common.providers.provider import Provider
+from smolmodels.internal.common.datasets.adapter import DatasetAdapter
 from smolmodels.internal.common.providers.provider_factory import ProviderFactory
 from smolmodels.internal.data_generation.generator import generate_data, DataGenerationRequest
 from smolmodels.internal.models.generators import generate
@@ -145,8 +147,7 @@ class Model:
         self.output_schema = output_schema
         self.input_schema = input_schema
         self.constraints = constraints or []
-        self.training_data = None
-        self.synthetic_data = None
+        self.training_data: pd.DataFrame | None = None
 
         # The model's mutable state is defined by these fields
         self.state = ModelState.DRAFT
@@ -165,9 +166,9 @@ class Model:
 
     def build(
         self,
-        dataset: Optional[Union[str, pd.DataFrame]] = None,
+        dataset: pd.DataFrame | np.ndarray = None,
         directives: List[Directive] = None,
-        generate_samples: Optional[Union[int, Dict[str, Any]]] = None,
+        generate_samples: Union[int, Dict[str, Any]] = None,
         callbacks: List[Callback] = None,
         isolation: Literal["local", "subprocess", "docker"] = "local",
         provider: str = "openai:gpt-4o-mini",
@@ -188,11 +189,8 @@ class Model:
             provider: Provider = ProviderFactory.create(provider)
             self.state = ModelState.BUILDING
 
-            # Handle existing dataset
-            if isinstance(dataset, str):
-                self.training_data = pd.read_csv(dataset)
-            elif isinstance(dataset, pd.DataFrame):
-                self.training_data = dataset.copy()
+            # Convert dataset to internal format
+            self.training_data = DatasetAdapter.convert(dataset) if dataset is not None else None
 
             # Handle data generation if requested
             if generate_samples is not None:
@@ -208,13 +206,13 @@ class Model:
                     existing_data=self.training_data,
                 )
 
-                self.synthetic_data = generate_data(provider, request)
+                synthetic_data = generate_data(provider, request)
 
                 # Handle augmentation
                 if self.training_data is not None and datagen_config.augment_existing:
-                    self.training_data = pd.concat([self.training_data, self.synthetic_data], ignore_index=True)
+                    self.training_data = pd.concat([self.training_data, synthetic_data], ignore_index=True)
                 else:
-                    self.training_data = self.synthetic_data
+                    self.training_data = synthetic_data
 
             # Validate we have training data from some source
             if self.training_data is None:

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -137,25 +137,6 @@ class TestDataGeneration:
         pd.testing.assert_frame_equal(model.training_data, existing_data)
         assert model.state.value == "ready"
 
-    def test_load_dataset_from_csv(self, sample_schema):
-        """Test loading dataset from CSV file"""
-        with patch("pandas.read_csv") as mock_read_csv:
-            mock_read_csv.return_value = pd.DataFrame(
-                {
-                    "square_feet": [1000, 1500, 2000],
-                    "bedrooms": [2, 3, 4],
-                    "location": ["A", "B", "C"],
-                    "price": [200000, 300000, 400000],
-                }
-            )
-
-            model = Model(intent="Predict house prices based on features", **sample_schema)
-            model.build(dataset="test.csv")
-
-            mock_read_csv.assert_called_once_with("test.csv")
-            assert model.training_data is not None
-            assert model.state.value == "ready"
-
 
 class TestSMOTEOversampling:
     def test_smote_maintains_class_proportions(self):


### PR DESCRIPTION
This PR aims to improve the consistency and extensibility of the library's handling of datasets. Previously the input dataset could be either a `str` or a `pandas.DataFrame`, but if it was a string, it was implicitly assumed that this had to be referring to a CSV file. This was a confusing and irritating user experience.

Now, the library no longer allows filling the `dataset` parameter with a path, which means we don't have to support loading all sorts of different file types on our side. Instead, the user can pass a dataset object directly, allowing them to handle the data loading using whatever tools suit their workflow. Currently, only `pandas.DataFrame` and `numpy.ndarray` are supported, but we'll add support for other dataset types in the future.

This PR begins to address the problem outlined in #23.

Enhancements to dataset handling:

* [`smolmodels/internal/common/datasets/adapter.py`](diffhunk://#diff-667133f725f07af43bccb6d9ed004067a8dd1e50ec78b43da06417d83dfc0c9eR1-R49): Introduced the `DatasetAdapter` class, which converts various dataset formats into a standard Pandas DataFrame representation. This class supports Pandas DataFrames and NumPy arrays, with future plans to support lazy datasets and integrations with PyTorch, TensorFlow, and Hugging Face datasets.
* [`smolmodels/models.py`](diffhunk://#diff-3413f166cbb2f0c4ebcab705b872c0f0646413a50eda24d41abf2bec4f332169L191-R193): Updated the `build` method to use the `DatasetAdapter` for converting datasets to a Pandas DataFrame. This change ensures consistent handling of datasets within the library. [[1]](diffhunk://#diff-3413f166cbb2f0c4ebcab705b872c0f0646413a50eda24d41abf2bec4f332169L191-R193) [[2]](diffhunk://#diff-3413f166cbb2f0c4ebcab705b872c0f0646413a50eda24d41abf2bec4f332169L211-R215)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R39): Modified examples to use `pd.read_csv` for loading datasets instead of passing file paths directly to the `build` method. This change reflects the new dataset handling approach. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R39) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R122) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R163)

Configuration updates:

* [`smolmodels/config.py`](diffhunk://#diff-47f0885acf9fa6bd5b393387827011c4c9e2d46abbfac1d127f2f4744146a035L33-R38): Changed the `training_data_path` default value to use Parquet format and updated the prompt templates to reflect this change. [[1]](diffhunk://#diff-47f0885acf9fa6bd5b393387827011c4c9e2d46abbfac1d127f2f4744146a035L33-R38) [[2]](diffhunk://#diff-47f0885acf9fa6bd5b393387827011c4c9e2d46abbfac1d127f2f4744146a035L91-R92) [[3]](diffhunk://#diff-47f0885acf9fa6bd5b393387827011c4c9e2d46abbfac1d127f2f4744146a035L108-R109)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the version to `0.1.3` and added `pyarrow` as a dependency to support Parquet file handling. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R43)

Other code updates:

* [`smolmodels/internal/models/execution/process_executor.py`](diffhunk://#diff-68f5abc734bbff221390b1fdae57ee884995b1303a03d690c4c8968010a8e4e5L81-R83): Updated the `run` method to write datasets to Parquet files instead of CSV files. This change aligns with the new configuration settings.