### PR TITLE
fix: configure logging without modifying root logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.4.0"
+version = "0.4.1"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.4.1"
+version = "0.4.0"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/config.py
+++ b/smolmodels/config.py
@@ -2,9 +2,15 @@
 Configuration for the smolmodels library.
 """
 
+import logging
+import warnings
 from dataclasses import dataclass, field
 from string import Template
 from typing import List
+
+# configure warnings
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 @dataclass(frozen=True)
@@ -247,3 +253,26 @@ def load_config() -> _Config:
 
 
 config: _Config = load_config()
+
+
+# Default logging configuration
+def configure_logging(level: str | int = logging.INFO, file: str = None) -> None:
+    # Configure the library's root logger
+    sm_root_logger = logging.getLogger("smolmodels")
+    sm_root_logger.setLevel(level)
+
+    # Define a common formatter
+    formatter = logging.Formatter(config.logging.format)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.stream.reconfigure(encoding="utf-8")  # Set UTF-8 encoding
+    stream_handler.setFormatter(formatter)
+    sm_root_logger.addHandler(stream_handler)
+
+    if file:
+        file_handler = logging.FileHandler(file, encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        sm_root_logger.addHandler(file_handler)
+
+
+configure_logging(level=config.logging.level)

--- a/smolmodels/internal/data_generation/__init__.py
+++ b/smolmodels/internal/data_generation/__init__.py
@@ -6,32 +6,4 @@ data distribution, either with data or without data (low-data regime). The servi
 validating the synthetic data against real data, if available.
 """
 
-import logging
-import warnings
-
-from .config import config
-
-
-# configure warnings
-warnings.filterwarnings("ignore", category=FutureWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-# configure logging
-logger = logging.getLogger()  # Get the root logger
-logger.setLevel(logging.DEBUG)  # Set the root logger's level
-
-# Configure handlers
-stream_handler = logging.StreamHandler()
-stream_handler.setLevel(logging.WARNING)
-stream_handler.stream.reconfigure(encoding="utf-8")  # Set UTF-8 encoding
-
-file_handler = logging.FileHandler("smolmodels.log", encoding="utf-8")
-file_handler.setLevel(logging.DEBUG)
-
-# Define a common formatter
-formatter = logging.Formatter(config.FORMAT)
-stream_handler.setFormatter(formatter)
-file_handler.setFormatter(formatter)
-
-# Add handlers to the root logger
-logger.addHandler(stream_handler)
-logger.addHandler(file_handler)
+from .config import config as config


### PR DESCRIPTION
This PR fixes an issue whereby the library actually makes changes to the `logging` library's root logger. What this means is that it won't play nice with a wider project that is using `smolmodels`.