### PR TITLE
fix: change early release banner to be more helpful

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plain words. You explain the task, and the library builds a model for you, inclu
 engineering, training, and packaging.
 </div>
 
-> [!NOTE]
+> [!INFO]
 > This library is in early development, and we're actively working on new features and improvements! Please report any
 > bugs or share your feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
 > or [Discord](https://discord.gg/3czW7BMj) 💛

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ plain words. You explain the task, and the library builds a model for you, inclu
 engineering, training, and packaging.
 </div>
 
-> [!WARNING]
-> This library is in early development, and we're actively working on new features and improvements. Please report any
-> bugs or feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
+> [!INFO]
+> This library is in early development, and we're actively working on new features and improvements! Please report any
+> bugs or share your feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
 > or [Discord](https://discord.gg/3czW7BMj) 💛
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ plain words. You explain the task, and the library builds a model for you, inclu
 engineering, training, and packaging.
 </div>
 
-> [!INFO]
+> [!NOTE]
 > This library is in early development, and we're actively working on new features and improvements! Please report any
 > bugs or share your feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
 > or [Discord](https://discord.gg/3czW7BMj) 💛

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ engineering, training, and packaging.
 </div>
 
 > [!WARNING]
-> This library is in early development and is not yet suitable for production use. We are actively working on
-> improving the library and adding new features. If you encounter any issues, please report them on GitHub or Discord.
+> This library is in early development, and we're actively working on new features and improvements. Please report any
+> bugs or feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
+> or [Discord](https://discord.gg/3czW7BMj) 💛
 
 
 ## 1. Quickstart


### PR DESCRIPTION
This PR makes a minor adjustment to the "early release" warning to make it more concise and helpful.