### PR TITLE
chore: remove PyPI downloads badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/smolmodels.svg)](https://pypi.org/project/smolmodels/)
 [![Discord](https://img.shields.io/discord/1300920499886358529?logo=discord&logoColor=white)](https://discord.gg/3czW7BMj)
-[![PyPI Downloads](https://static.pepy.tech/badge/smolmodels)](https://pepy.tech/projects/smolmodels)
 
 Build machine learning models using natural language and minimal code
 


### PR DESCRIPTION
Remove PyPI badge from readme as the number is not reliable.