### PR TITLE
fix: update previously expired discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ engineering, training, and packaging.
 > [!NOTE]
 > This library is in early development, and we're actively working on new features and improvements! Please report any
 > bugs or share your feature requests on [GitHub](https://github.com/plexe-ai/smolmodels/issues) 
-> or [Discord](https://discord.gg/3czW7BMj) 💛
+> or [Discord](https://discord.gg/SefZDepGMv) 💛
 
 
 ## 1. Quickstart

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # smolmodels ✨
 
 [![PyPI version](https://img.shields.io/pypi/v/smolmodels.svg)](https://pypi.org/project/smolmodels/)
-[![Discord](https://img.shields.io/discord/1300920499886358529?logo=discord&logoColor=white)](https://discord.gg/3czW7BMj)
+[![Discord](https://img.shields.io/discord/1300920499886358529?logo=discord&logoColor=white)](https://discord.gg/SefZDepGMv)
 
 Build machine learning models using natural language and minimal code
 


### PR DESCRIPTION
Previous Discord link had expired as it was only valid for 7 days.