### PR TITLE
feat: add option for lightweight installation

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
+        dependencies: ['lightweight', 'all']
     env:
       GOOGLE_API_KEY: ${{ vars.GOOGLE_API_KEY }}
       OPENAI_API_KEY: ${{ vars.OPENAI_API_KEY }}
@@ -58,7 +59,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install
+          if [ "${{ matrix.dependencies }}" == "all" ]; then
+            poetry install -E all
+          else
+            poetry install
+          fi
 
       - name: Run Tests
         run: poetry run pytest tests/unit/

--- a/README.md
+++ b/README.md
@@ -156,13 +156,23 @@ model.build(provider="openai/gpt-4o-mini", ...)
 See the section on installation and setup for more details on supported providers and how to configure API keys.
 
 ## 3. Installation & Setup
-Install the library in the usual manner:
+### 3.1. Installation Options
+
+`smolmodels` offers different installation options to suit your needs:
 
 ```bash
-pip install smolmodels
+pip install smolmodels                  # default installation without deep learning dependencies
+pip install smolmodels[lightweight]     # explicitly lightweight, equivalent to 'smolmodels'
+
+pip install smolmodels[all]             # full installation including deep learning dependencies
+pip install smolmodels[deep-learning]   # specifically for deep-learning, equivalent to 'smolmodels[all]'
 ```
 
-Set your API key as an environment variable based on which provider you want to use. For example:
+The lightweight installation is suitable for most machine learning tasks and reduces the installation size 
+significantly. If you need deep learning capabilities, use the `[all]` or `[deep-learning]` option.
+
+### 3.2. API Keys Setup
+Set your API key as an environment variable based on which provider you want to use:
 
 ```bash
 # For OpenAI
@@ -219,5 +229,6 @@ The web interface provides an easy way to create models, view their status, and 
 - [X] Fine-tuning and transfer learning for small pre-trained models
 - [X] Use Pydantic for schemas and split data generation into a separate module
 - [X] Smolmodels self-hosted platform ⭐ (More details coming soon!)
+- [X] Lightweight installation option without heavy deep learning dependencies
 - [ ] Support for non-tabular data types in model generation
 - [ ] File upload to docker containers

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "accelerate"
 version = "0.24.1"
 description = "Accelerate"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 files = [
     {file = "accelerate-0.24.1-py3-none-any.whl", hash = "sha256:866dec394da60e8da964be212379d8cf6cc0d0e5e28a7c0d7e09507715d21c61"},
@@ -2515,7 +2515,7 @@ testing = ["pytest"]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
@@ -2734,7 +2734,7 @@ files = [
 name = "networkx"
 version = "3.4.2"
 description = "Python package for creating and manipulating graphs and networks"
-optional = false
+optional = true
 python-versions = ">=3.10"
 files = [
     {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
@@ -2826,7 +2826,7 @@ files = [
 name = "nvidia-cublas-cu12"
 version = "12.1.3.1"
 description = "CUBLAS native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cublas_cu12-12.1.3.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:ee53ccca76a6fc08fb9701aa95b6ceb242cdaab118c3bb152af4e579af792728"},
@@ -2837,7 +2837,7 @@ files = [
 name = "nvidia-cuda-cupti-cu12"
 version = "12.1.105"
 description = "CUDA profiling tools runtime libs."
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:e54fde3983165c624cb79254ae9818a456eb6e87a7fd4d56a2352c24ee542d7e"},
@@ -2848,7 +2848,7 @@ files = [
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.1.105"
 description = "NVRTC native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:339b385f50c309763ca65456ec75e17bbefcbbf2893f462cb8b90584cd27a1c2"},
@@ -2859,7 +2859,7 @@ files = [
 name = "nvidia-cuda-runtime-cu12"
 version = "12.1.105"
 description = "CUDA Runtime native Libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:6e258468ddf5796e25f1dc591a31029fa317d97a0a94ed93468fc86301d61e40"},
@@ -2870,7 +2870,7 @@ files = [
 name = "nvidia-cudnn-cu12"
 version = "8.9.2.26"
 description = "cuDNN runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cudnn_cu12-8.9.2.26-py3-none-manylinux1_x86_64.whl", hash = "sha256:5ccb288774fdfb07a7e7025ffec286971c06d8d7b4fb162525334616d7629ff9"},
@@ -2883,7 +2883,7 @@ nvidia-cublas-cu12 = "*"
 name = "nvidia-cufft-cu12"
 version = "11.0.2.54"
 description = "CUFFT native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cufft_cu12-11.0.2.54-py3-none-manylinux1_x86_64.whl", hash = "sha256:794e3948a1aa71fd817c3775866943936774d1c14e7628c74f6f7417224cdf56"},
@@ -2894,7 +2894,7 @@ files = [
 name = "nvidia-curand-cu12"
 version = "10.3.2.106"
 description = "CURAND native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_curand_cu12-10.3.2.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:9d264c5036dde4e64f1de8c50ae753237c12e0b1348738169cd0f8a536c0e1e0"},
@@ -2905,7 +2905,7 @@ files = [
 name = "nvidia-cusolver-cu12"
 version = "11.4.5.107"
 description = "CUDA solver native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cusolver_cu12-11.4.5.107-py3-none-manylinux1_x86_64.whl", hash = "sha256:8a7ec542f0412294b15072fa7dab71d31334014a69f953004ea7a118206fe0dd"},
@@ -2921,7 +2921,7 @@ nvidia-nvjitlink-cu12 = "*"
 name = "nvidia-cusparse-cu12"
 version = "12.1.0.106"
 description = "CUSPARSE native runtime libraries"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_cusparse_cu12-12.1.0.106-py3-none-manylinux1_x86_64.whl", hash = "sha256:f3b50f42cf363f86ab21f720998517a659a48131e8d538dc02f8768237bd884c"},
@@ -2945,7 +2945,7 @@ files = [
 name = "nvidia-nvjitlink-cu12"
 version = "12.8.61"
 description = "Nvidia JIT LTO Library"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17"},
@@ -2957,7 +2957,7 @@ files = [
 name = "nvidia-nvtx-cu12"
 version = "12.1.105"
 description = "NVIDIA Tools Extension"
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "nvidia_nvtx_cu12-12.1.105-py3-none-manylinux1_x86_64.whl", hash = "sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5"},
@@ -4423,7 +4423,7 @@ files = [
 name = "safetensors"
 version = "0.4.5"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "safetensors-0.4.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a63eaccd22243c67e4f2b1c3e258b257effc4acd78f3b9d397edc8cf8f1298a7"},
@@ -4862,7 +4862,7 @@ pbr = ">=2.0.0"
 name = "sympy"
 version = "1.13.3"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "sympy-1.13.3-py3-none-any.whl", hash = "sha256:54612cf55a62755ee71824ce692986f23c88ffa77207b30c1368eda4a7060f73"},
@@ -5118,7 +5118,7 @@ testing = ["black (==22.3)", "datasets", "numpy", "pytest", "requests"]
 name = "torch"
 version = "2.2.2"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 files = [
     {file = "torch-2.2.2-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:bc889d311a855dd2dfd164daf8cc903a6b7273a747189cebafdd89106e4ad585"},
@@ -5257,7 +5257,7 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 name = "transformers"
 version = "4.35.2"
 description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
-optional = false
+optional = true
 python-versions = ">=3.8.0"
 files = [
     {file = "transformers-4.35.2-py3-none-any.whl", hash = "sha256:9dfa76f8692379544ead84d98f537be01cd1070de75c74efb13abcbc938fbe2f"},
@@ -5325,7 +5325,7 @@ vision = ["Pillow (<10.0.0)"]
 name = "triton"
 version = "2.2.0"
 description = "A language and compiler for custom Deep Learning operations"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "triton-2.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2294514340cfe4e8f4f9e5c66c702744c4a117d25e618bd08469d0bfed1e2e5"},
@@ -5676,7 +5676,12 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+all = ["accelerate", "safetensors", "tokenizers", "torch", "transformers"]
+deep-learning = ["accelerate", "safetensors", "tokenizers", "torch", "transformers"]
+lightweight = []
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "f2f6605c92bc4e4e69895e14601e13250185b6fbab5ae277bf51f493e18add75"
+content-hash = "f882b10df5382a683d4934908c7af7e27ef84adabbf37237f38938255bb25618"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.10.0"
+version = "0.11.0"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",
@@ -41,17 +41,23 @@ xgboost = "^2.1.3"
 instructor = { extras = ["anthropic"], version = "^1.7.2" }
 tenacity = "^9.0.0"
 pyarrow = "^19.0.0"
-torch = ">=2.0.0,<2.3.0"
 litellm = "^1.60.0"
 statsmodels = "^0.14.4"
 hypothesis = "^6.125.1"
-tokenizers = "^0.15.1"
 numpy = ">=1.23.2,<2.0.0"
-transformers = "4.35.2"
-accelerate = "0.24.1"
-safetensors = "^0.4.1"
 black = "^24.10.0"
 
+# Deep learning dependencies
+torch = { version = ">=2.0.0,<2.3.0", optional = true }
+transformers = { version = "4.35.2", optional = true }
+tokenizers = { version = "^0.15.1", optional = true }
+accelerate = { version = "0.24.1", optional = true }
+safetensors = { version = "^0.4.1", optional = true }
+
+[tool.poetry.extras]
+all = ["torch", "transformers", "tokenizers", "accelerate", "safetensors"]
+deep-learning = ["torch", "transformers", "tokenizers", "accelerate", "safetensors"]
+lightweight = []
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ def run_command(command):
 
 def main():
     print("Installing dependencies...")
+    print("Note: This installs the lightweight version of smolmodels by default.")
+    print("Available installation options:")
+    print("  poetry install                    # Default lightweight installation")
+    print("  poetry install -E lightweight     # Explicitly install lightweight version")
+    print("  poetry install -E all             # Full installation with deep learning support")
+    print("  poetry install -E deep-learning   # Only deep learning dependencies")
     run_command("poetry install")
 
     print("Installing pre-commit hooks...")

--- a/smolmodels/internal/common/utils/dependency_utils.py
+++ b/smolmodels/internal/common/utils/dependency_utils.py
@@ -1,0 +1,50 @@
+"""
+Utilities for handling optional dependencies.
+"""
+
+import functools
+import logging
+from typing import Callable, TypeVar, cast, Any
+
+from smolmodels.config import is_package_available
+
+logger = logging.getLogger(__name__)
+
+# Type variable for the callable return type
+T = TypeVar("T")
+
+
+def requires_package(package_name: str, error_message: str = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Decorator that checks if a required package is installed before executing a function.
+    If the package is not available, logs a warning and returns None.
+
+    Example:
+    @requires_package('torch')
+    def train_neural_network(data):
+        # This function will only run if torch is installed
+        import torch
+        # ...training code...
+
+    :param package_name: Name of the package that needs to be available
+    :param error_message: Custom error message to display if the package is not available
+    :return: Decorator function
+    """
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            if is_package_available(package_name):
+                return func(*args, **kwargs)
+            else:
+                default_message = (
+                    f"The '{package_name}' package is required for this functionality but is not installed. "
+                    f"Install it with 'pip install smolmodels[all]' or 'pip install {package_name}'."
+                )
+                message = error_message or default_message
+                logger.warning(message)
+                return cast(T, None)
+
+        return wrapper
+
+    return decorator

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,34 @@
 [tox]
 isolated_build = True
-envlist = py311, py312
+envlist = py311-light, py311-all, py312-light, py312-all
 
 [testenv]
 skip_install = true
 allowlist_externals = poetry
 passenv = *
-basepython =
-    py311: python3.11
-    py312: python3.12
+commands =
+    poetry run pytest {posargs}
+
+[testenv:py311-light]
+basepython = python3.11
 commands_pre =
     poetry env use {envpython}
     poetry install
-commands =
-    poetry run pytest {posargs}
+
+[testenv:py311-all]
+basepython = python3.11
+commands_pre =
+    poetry env use {envpython}
+    poetry install -E all
+
+[testenv:py312-light]
+basepython = python3.12
+commands_pre =
+    poetry env use {envpython}
+    poetry install
+
+[testenv:py312-all]
+basepython = python3.12
+commands_pre =
+    poetry env use {envpython}
+    poetry install -E all


### PR DESCRIPTION
This PR adds the ability to install a "lightweight" variant of the library without heavy deep learning dependencies. In most ML tasks the quality of your model is determined by the quality and size of your data, rather than the algorithm being used, so it makes sense to give users the option to use a "no deep learning" backend if they prefer a lightweight installation.

The variants are detailed in the readme, but in a nutshell:

1. `smolmodels`: default installation, required packages only
2. `smolmodels[lightweight]`: same as default
3. `smolmodels[all]`: includes deep learning

The LLM prompts for code generation take into account whether DL libraries are available. The tox setup for tests and GH actions workflow have been updated as well.