### PR TITLE
fix: generated predictor code uses abs paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.11.0"
+version = "0.11.1"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/internal/models/generation/inference.py
+++ b/smolmodels/internal/models/generation/inference.py
@@ -118,7 +118,7 @@ class InferenceCodeGenerator:
         :param filedir: The directory in which the predictor should expect model files.
         :return: The generated inference code.
         """
-        model_dir = Path(filedir).resolve()
+        model_dir = Path(filedir)
 
         # Stage 1: Generate model loading code
         model_loading_code = self._generate_model_loading(training_code, model_dir)


### PR DESCRIPTION
This PR fixes a bug that prevents `smolmodels` from being used for inference in a different environment than the one in which it was trained. The bug is caused by an absolute file path being inserted into the "predictor" code. The absolute path is valid in the env in which the model was trained, but most likely does not exist in a different env to which you want to deploy the model.