### PR TITLE
hotfix: planning prompt does not include metric to optimise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.12.3"
+version = "0.12.4"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/config.py
+++ b/smolmodels/config.py
@@ -136,16 +136,16 @@ class _Config:
             """
             base_prompt = (
                 "Write a solution plan for the machine learning problem outlined below. The solution must produce "
-                "a model that achieves the best possible performance on ${metric}.\n\n"
+                "a model that achieves the best possible performance on ${metric_to_optimise}.\n\n"
             )
 
             # Include fine-tuning suggestion only if deep learning packages are available
             if self.deep_learning_available:
-                base_prompt += "If appropriate, consider using pre-trained models under 20MB that can be fine-tuned with the provided data."
+                base_prompt += "If appropriate, consider using pre-trained models under 20MB that can be fine-tuned with the provided data.\n\n"
 
             base_prompt += (
                 "# TASK:\n${problem_statement}\n\n"
-                "# PREVIOUS ATTEMPTS, IF ANY:**\n${context}\n\n"
+                "# PREVIOUS ATTEMPTS, IF ANY:\n${context}\n\n"
                 "The solution concept should be explained in 3-5 sentences. Do not include an implementation of the "
                 "solution, though you can include small code snippets if relevant to explain the plan. "
                 "Do not suggest doing EDA, ensembling, or hyperparameter tuning. "

--- a/smolmodels/fileio.py
+++ b/smolmodels/fileio.py
@@ -175,8 +175,6 @@ def load_model(path: str | Path) -> Model:
                 if member.name.startswith("artifacts/") and not member.isdir():
                     file_data = tar.extractfile(member)
                     if file_data:
-                        print(f"Loading artifact: {member.name}")
-                        print(f"Name will be {Path(member.name).name}")
                         artifact_handles.append(Artifact.from_data(Path(member.name).name, file_data.read()))
 
             # Reconstruct Metric object if metrics data exists

--- a/smolmodels/internal/models/generators.py
+++ b/smolmodels/internal/models/generators.py
@@ -142,12 +142,15 @@ class ModelGenerator:
         validation_datasets = {}
         test_datasets = {}
 
+        logger.info("🔪 Splitting datasets into train, validation, and test sets")
         for name, dataset in datasets.items():
-            logger.info(f"🔪 Splitting dataset {name} into train, validation, and test sets")
             train_ds, val_ds, test_ds = dataset.split(train_ratio=0.9, val_ratio=0.1, test_ratio=0.0)
             train_datasets[f"{name}_train"] = train_ds
             validation_datasets[f"{name}_val"] = val_ds
             test_datasets[f"{name}_test"] = test_ds
+            logger.info(
+                f"✅  Split dataset {name} into train/validation/test with sizes {len(train_ds)}/{len(val_ds)}/{len(test_ds)}"
+            )
 
         # Define the problem statement to be used; it can change at each call of generate()
         task = join_task_statement(self.intent, self.input_schema, self.output_schema, self.constraints, directives)


### PR DESCRIPTION
This PR addresses a few minor model quality issues, which I spotted when I encountered a case of a "heart attack prediction" model which kept returning a label `1` no matter how I changed the inputs. None of these changes guarantee such a model would not be built again.

1. The "come up with a plan" prompt does not include the metric to optimise for. I suspect this is the reason why we often see training runs that do not produce the right metric.
2. Some minor logging improvements.