### PR TITLE
feat: add explicit per-run timeout + logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smolmodels"
-version = "0.12.5"
+version = "0.12.6"
 description = "A framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/smolmodels/config.py
+++ b/smolmodels/config.py
@@ -56,7 +56,6 @@ class _Config:
 
     @dataclass(frozen=True)
     class _ExecutionConfig:
-        timeout: int = field(default=300)
         runfile_name: str = field(default="execution_script.py")
 
     @dataclass(frozen=True)

--- a/smolmodels/internal/models/execution/process_executor.py
+++ b/smolmodels/internal/models/execution/process_executor.py
@@ -49,8 +49,8 @@ class ProcessExecutor(Executor):
         code: str,
         working_dir: Path | str,
         datasets: Dict[str, TabularConvertible],
+        timeout: int,
         code_execution_file_name: str = config.execution.runfile_name,
-        timeout: int = config.execution.timeout,
     ):
         """
         Initialize the ProcessExecutor.
@@ -132,7 +132,9 @@ class ProcessExecutor(Executor):
             return ExecutionResult(
                 term_out=[],
                 exec_time=self.timeout,
-                exception=TimeoutError(f"Execution exceeded {self.timeout}s timeout"),
+                exception=TimeoutError(
+                    f"Execution exceeded {self.timeout}s timeout - individual run timeout limit reached"
+                ),
             )
 
     def cleanup(self):

--- a/smolmodels/internal/models/generators.py
+++ b/smolmodels/internal/models/generators.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 
 from smolmodels.config import config
 from smolmodels.constraints import Constraint
-from smolmodels.directives import Directive
 from smolmodels.internal.common.datasets.interface import TabularConvertible
 from smolmodels.internal.common.provider import Provider
 from smolmodels.internal.models.entities.graph import Graph
@@ -106,6 +105,7 @@ class ModelGenerator:
         self.constraints: List[Constraint] = constraints or []
         self.provider: Provider = provider
         self.isolation: str = "subprocess"  # todo: parameterise and support other isolation methods
+        self.run_timeout = None
         # Initialise the model solution graph, code generators, etc.
         self.graph: Graph = Graph()
         self.plan_generator = SolutionPlanGenerator(provider)  # todo: allow dependency injection for these
@@ -117,22 +117,25 @@ class ModelGenerator:
     def generate(
         self,
         datasets: Dict[str, TabularConvertible],  # TODO: support Dataset instead of just TabularConvertible
+        run_timeout: int,
         timeout: int = None,
         max_iterations=None,
-        directives: List[Directive] = None,
     ) -> GenerationResult:
         """
         Generates a machine learning model based on the given problem statement, input schema, and output schema.
 
         :param datasets: The dataset to use for training the model.
-        :param timeout: The maximum time to spend generating the model, in seconds.
+        :param timeout: The maximum total time to spend generating the model, in seconds (all iterations combined).
         :param max_iterations: The maximum number of iterations to spend generating the model.
-        :param directives: A list of directives to apply to the model generation process.
+        :param run_timeout: The maximum time to spend on each individual model training run, in seconds.
         :return: A GenerationResult object containing the training and inference code, and the predictor module.
         """
         # Check either timeout or max_iterations is set
         if timeout is None and max_iterations is None:
             raise ValueError("Either timeout or max_iterations must be set")
+
+        # Store the individual_run_timeout for later use if provided
+        self.run_timeout = run_timeout
 
         # Start the model generation run
         run_id = f"run-{datetime.now().isoformat()}".replace(":", "-").replace(".", "-")
@@ -282,7 +285,7 @@ class ModelGenerator:
                         code=node.training_code,
                         working_dir=f"./workdir/{run_name}/",
                         datasets=combined_datasets,
-                        timeout=config.execution.timeout,
+                        timeout=self.run_timeout,
                         code_execution_file_name=config.execution.runfile_name,
                     ),
                     metric_to_optimise=target_metric,
@@ -290,6 +293,12 @@ class ModelGenerator:
 
                 # If the code raised an exception, attempt to fix again
                 if node.exception_was_raised:
+                    # Special logging for TimeoutError as this is an important case to flag
+                    if isinstance(node.exception, TimeoutError):
+                        logger.warning(
+                            f"❌  Model training timed out after {self.run_timeout}s - individual run timeout exceeded"
+                        )
+
                     review = self.train_generator.review_training_code(
                         node.training_code, task, node.solution_plan, str(node.exception)
                     )

--- a/smolmodels/internal/models/generators.py
+++ b/smolmodels/internal/models/generators.py
@@ -130,10 +130,6 @@ class ModelGenerator:
         :param run_timeout: The maximum time to spend on each individual model training run, in seconds.
         :return: A GenerationResult object containing the training and inference code, and the predictor module.
         """
-        # Check either timeout or max_iterations is set
-        if timeout is None and max_iterations is None:
-            raise ValueError("Either timeout or max_iterations must be set")
-
         # Store the individual_run_timeout for later use if provided
         self.run_timeout = run_timeout
 

--- a/smolmodels/models.py
+++ b/smolmodels/models.py
@@ -152,6 +152,12 @@ class Model:
         :param run_timeout: maximum time in seconds for each individual model training run
         :return:
         """
+        # Ensure timeout, max_iterations, and run_timeout make sense
+        if timeout is None and max_iterations is None:
+            raise ValueError("At least one of 'timeout' or 'max_iterations' must be set")
+        if run_timeout >= timeout:
+            raise ValueError(f"'run_timeout' ({run_timeout}s) must be smaller than 'timeout' ({timeout}s)")
+
         # TODO: validate that schema features are present in the dataset
         # TODO: validate that datasets do not contain duplicate features
         try:

--- a/smolmodels/models.py
+++ b/smolmodels/models.py
@@ -139,6 +139,7 @@ class Model:
         directives: List[Directive] = None,
         timeout: int = None,
         max_iterations: int = None,
+        run_timeout: int = 1800,
     ) -> None:
         """
         Build the model using the provided dataset, directives, and optional data generation configuration.
@@ -146,8 +147,9 @@ class Model:
         :param datasets: the datasets to use for training the model
         :param provider: the provider to use for model building
         :param directives: instructions related to the model building process - not the model itself
-        :param timeout: maximum time in seconds to spend building the model
+        :param timeout: maximum total time in seconds to spend building the model (all iterations combined)
         :param max_iterations: maximum number of iterations to spend building the model
+        :param run_timeout: maximum time in seconds for each individual model training run
         :return:
         """
         # TODO: validate that schema features are present in the dataset
@@ -176,7 +178,12 @@ class Model:
             self.model_generator = ModelGenerator(
                 self.intent, self.input_schema, self.output_schema, provider, self.constraints
             )
-            generated = self.model_generator.generate(self.training_data, timeout, max_iterations, directives)
+            generated = self.model_generator.generate(
+                datasets=self.training_data,
+                run_timeout=run_timeout,
+                timeout=timeout,
+                max_iterations=max_iterations,
+            )
 
             # Step 4: update model state and attributes
             self.trainer_source = generated.training_source_code

--- a/smolmodels/models.py
+++ b/smolmodels/models.py
@@ -155,8 +155,8 @@ class Model:
         # Ensure timeout, max_iterations, and run_timeout make sense
         if timeout is None and max_iterations is None:
             raise ValueError("At least one of 'timeout' or 'max_iterations' must be set")
-        if run_timeout >= timeout:
-            raise ValueError(f"'run_timeout' ({run_timeout}s) must be smaller than 'timeout' ({timeout}s)")
+        if run_timeout is not None and timeout is not None and run_timeout > timeout:
+            raise ValueError(f"Run timeout ({run_timeout}s) cannot exceed total timeout ({timeout}s)")
 
         # TODO: validate that schema features are present in the dataset
         # TODO: validate that datasets do not contain duplicate features


### PR DESCRIPTION
This PR fixes a bug whereby model training runs always have a fixed timeout of 300 seconds. This bug likely largely explains the high % of model build failures whenever the ML task is any more complex than a toy problem. This PR also adds explicit handling for timeout errors when running a model build, so that timeouts at the individual run level are properly flagged in terminal output.